### PR TITLE
Chooser - Update Selected Value

### DIFF
--- a/smartdashboard/src/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
+++ b/smartdashboard/src/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
@@ -56,6 +56,10 @@ public class Chooser extends AbstractTableWidget implements ITableListener
 		{
 			display.setSelected(source.getString(SELECTED));
 		}
+
+		if (source.getString(SELECTED, null) == null) {
+			source.putString(SELECTED, source.getString(DEFAULT, choices.get(0)));
+		}
 	}
 
 	@Override

--- a/smartdashboard/src/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
+++ b/smartdashboard/src/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
@@ -57,7 +57,7 @@ public class Chooser extends AbstractTableWidget implements ITableListener
 			display.setSelected(source.getString(SELECTED));
 		}
 
-		if (source.getString(SELECTED, null) == null) {
+		if (!source.containsKey(SELECTED)) {
 			source.putString(SELECTED, source.getString(DEFAULT, choices.get(0)));
 		}
 	}


### PR DESCRIPTION
closes #2 

If the selected value in networktables is null and we have a selected value.  Update networktables.  If we do not have a selected value, use the default.  If there is no default, use the first option.  