### PR TITLE
Handle the stream ending in the middle of an image.

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/MjpgStreamViewer.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/MjpgStreamViewer.java
@@ -213,6 +213,7 @@ public abstract class MjpgStreamViewer extends StaticWidget {
           imageToDraw = null;
           repaint();
           System.out.println(ex.getMessage());
+          cameraChanged();
         } catch (InterruptedException ex) {
           Thread.currentThread().interrupt();
           throw new RuntimeException(ex);
@@ -266,6 +267,9 @@ public abstract class MjpgStreamViewer extends StaticWidget {
         throws IOException {
       for (int i = 0; i < bytes.length; ) {
         int b = stream.read();
+        if (b == -1) {
+          throw new IOException("End of Stream reached");
+        }
         if (buffer != null) {
           buffer.write(b);
         }


### PR DESCRIPTION
InputStream returns -1 when stream ends. Previously if a stream end
without a complete image it would spin reading -1 and filling the
buffer.