### PR TITLE
Making the table headers sortable

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
@@ -133,6 +133,7 @@ public class RobotPreferences extends StaticWidget implements ITableListener {
     table = new JTable(model);
     table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     table.getTableHeader().setReorderingAllowed(false);
+    table.setAutoCreateRowSorter(true);
 
 
     JPanel buttonPanel = new JPanel();


### PR DESCRIPTION
Makes it much easier to find the parameter you want to change.  Last year I made (copied) the default robot preferences to add this ability, as we had many preferences and it was nice to get them in alphabetical order to find what we wanted to change on the SD