### PR TITLE
Fix chooser values reset if RoboRIO is offline when values are changed

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
@@ -156,16 +156,13 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
         selection = null;
       }
 
-      if (table != null && table.containsKey(SELECTED)) {
-        selection = table.getString(SELECTED);
-      }
-
       if (table != null && selection != null) {
         table.putString(SELECTED, selection);
         selected = buttons.get(selection);
         selected.setSelected(true);
       } else {
         if (table != null && table.containsKey(DEFAULT)) {
+          selection = table.getString(DEFAULT);
           selected = buttons.get(table.getString(DEFAULT));
           selected.setSelected(true);
         } else {


### PR DESCRIPTION
Closes #75 

This should fix the issue where the state of the radio buttons is not remembered when they are modified while not connected to the RoboRIO.