### PR TITLE
Allow for Camera selection over NetworkTables

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/CameraServerViewer.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/CameraServerViewer.java
@@ -2,8 +2,10 @@ package edu.wpi.first.smartdashboard.gui.elements;
 
 import edu.wpi.first.smartdashboard.properties.MultiProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
+import edu.wpi.first.smartdashboard.properties.StringProperty;
 import edu.wpi.first.wpilibj.networktables.NetworkTable;
 import edu.wpi.first.wpilibj.tables.ITable;
+import edu.wpi.first.wpilibj.tables.ITableListener;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -14,8 +16,13 @@ public class CameraServerViewer extends MjpgStreamViewer {
   private static final String STREAMS_KEY = "streams";
 
   public final MultiProperty cameraProperty = new MultiProperty(this, "Camera Choice");
+  public final StringProperty selectedCameraPathProperty
+      = new StringProperty(this, "Selected Camera Path", "");
 
   private ITable cameraTable;
+  private ITable rootTable = NetworkTable.getTable("");
+  private ITableListener selectedCameraPathListener
+      = (source, key, value, isNew) -> cameraProperty.setValue(value);
 
   @Override
   public void onInit() {
@@ -27,6 +34,9 @@ public class CameraServerViewer extends MjpgStreamViewer {
         cameraTable = (ITable) value;
       }
     }));
+
+    rootTable.addTableListener(selectedCameraPathProperty.getValue(),
+        selectedCameraPathListener, true);
   }
 
   @Override
@@ -34,6 +44,10 @@ public class CameraServerViewer extends MjpgStreamViewer {
     if (property == cameraProperty) {
       cameraTable = (ITable) cameraProperty.getValue();
       cameraChanged();
+    } else if (property == selectedCameraPathProperty) {
+      rootTable.removeTableListener(selectedCameraPathListener);
+      rootTable.addTableListener(selectedCameraPathProperty.getValue(),
+          selectedCameraPathListener, true);
     }
   }
 


### PR DESCRIPTION
This is broken right now.  For some reason,`immediateNotify` does not do what I think it does.

@PeterJohnson 