### PR TITLE
Fix delete in RobotPreferences so it deletes the correct row

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
@@ -70,10 +70,13 @@ public class RobotPreferences extends StaticWidget implements ITableListener {
         if (table.isEditing()) {
           table.getCellEditor().cancelCellEditing();
         }
-        int rowIndex = table.convertRowIndexToModel(table.getSelectedRow());
-        Map.Entry<String, Object> entry = model.getRow(rowIndex);
-        if (entry != null) {
-          model.delete(entry.getKey());
+        int viewIndex = table.getSelectedRow(); 
+        if (viewIndex != -1) {
+          int modelIndex = table.convertRowIndexToModel(viewIndex);
+          Map.Entry<String, Object> entry = model.getRow(modelIndex);
+          if (entry != null) {
+            model.delete(entry.getKey());
+          }
         }
       }
     });

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
@@ -70,7 +70,8 @@ public class RobotPreferences extends StaticWidget implements ITableListener {
         if (table.isEditing()) {
           table.getCellEditor().cancelCellEditing();
         }
-        Map.Entry<String, Object> entry = model.getRow(table.getSelectedRow());
+        int rowIndex = table.convertRowIndexToModel(table.getSelectedRow());
+        Map.Entry<String, Object> entry = model.getRow(rowIndex);
         if (entry != null) {
           model.delete(entry.getKey());
         }


### PR DESCRIPTION
There was a bug in the RobotPreferences where the "delete" button would not delete the currently selected row, if the table was sorted.  This PR fixes that.