### PR TITLE
Avoid corrupting save file when widget getType is null.

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
@@ -279,6 +279,10 @@ public class DashboardFrame extends JFrame {
       boolean isWidget = element instanceof Widget;
       assert isWidget || element instanceof StaticWidget;
       if (isWidget) {
+        if (((Widget) element).getType() == null) {
+          System.err.println("Unable to save element: " + ((Widget) element).getFieldName());
+          break;
+        }
         writer.beginWidget(((Widget) element).getFieldName(), ((Widget) element).getType()
             .getName(), element.getClass().getName());
       } else {

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
@@ -279,7 +279,11 @@ public class DashboardFrame extends JFrame {
       boolean isWidget = element instanceof Widget;
       assert isWidget || element instanceof StaticWidget;
       if (isWidget) {
-        if (((Widget) element).getType() == null) {
+        if (((Widget) element).getFieldName() == null) {
+          System.err.println("Unable to save element");
+          break;
+        }
+        if (((Widget) element).getType() == null || element.getClass().getName() == null) {
           System.err.println("Unable to save element: " + ((Widget) element).getFieldName());
           break;
         }


### PR DESCRIPTION
This has been seen randomly. The bad widget will not be saved, but
everything else will. Fixes #101