### PR TITLE
Fix issue #119

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/properties/StringProperty.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/properties/StringProperty.java
@@ -14,6 +14,19 @@ public class StringProperty extends TextInputProperty<String> {
   }
 
   @Override
+  public String getSaveValue() {
+    // In XML, the characters "&" and "<" are not valid in values by themselves
+    // Therefore here we replace these invalid characters by their escape sequences.
+    // Retrieve the save value from the superclass
+    String saveValue = super.getSaveValue();
+    // Replace &
+    saveValue = saveValue.replace("&", "&amp;");
+    // Replace <
+    saveValue = saveValue.replace("<", "&lt;");
+    return saveValue;
+  }
+
+  @Override
   protected String transformValue(Object value) {
     return value.toString();
   }


### PR DESCRIPTION
Fix issue #119, "MJPEG Stream Viewer URLs does not save & (ampersand) properly". `StringProperty` now overrides `Property.getSaveValue()` to replace the invalid characters "&" and "<" with their corresponding escape sequences.

This fixes the saving bug for not just MJPEG Viewers, but also labels and any other widgets that have string properties.