### PR TITLE
Allow entering an IP address & port for NetworkTables

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/HostParser.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/HostParser.java
@@ -1,0 +1,101 @@
+package edu.wpi.first.smartdashboard;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Parses a raw host string input to a consistent format.
+ */
+public final class HostParser {
+
+  private static final Logger log = Logger.getLogger(HostParser.class.getName());
+
+  public static final int DEFAULT_PORT = NetworkTableInstance.kDefaultPort;
+
+  /**
+   * Information about a NetworkTable server host.
+   */
+  public static final class NtHostInfo {
+    private final String host;
+    private final int port;
+
+    public static NtHostInfo onDefaultPort(String host) {
+      return new NtHostInfo(host, DEFAULT_PORT);
+    }
+
+    public NtHostInfo(String host, int port) {
+      this.host = Objects.requireNonNull(host, "host");
+      this.port = port;
+    }
+
+    /**
+     * Gets the host of the NetworkTable server.
+     * This can be an IP address like {@code "10.TE.AM.2"}, an mDNS address
+     * like {@code "roborio-TEAM-frc.local"}, or a team number like {@code "190"}.
+     */
+    public String getHost() {
+      return host;
+    }
+
+    /**
+     * Gets the team number for the roborio host, if specified.
+     *
+     * @return an optional integer for the team number, if one was specified
+     */
+    public int getTeam() {
+      if (getHost().matches("\\d{1,4}")) {
+        return Integer.parseInt(getHost());
+      } else {
+        return -1;
+      }
+    }
+
+    /**
+     * Gets the port the server is running on.
+     */
+    public int getPort() {
+      return port;
+    }
+  }
+
+  /**
+   * Parses the given input host string to a consistent format.
+   *
+   * @param rawHost the raw host like "190", "roborio-190-frc.local", "190:1736", etc.
+   *
+   * @return the host info for the given raw host information, or an empty optional
+   *     if the input string is invalid
+   */
+  public Optional<NtHostInfo> parse(String rawHost) {
+    try {
+      // Make sure the URI starts with http:// or https// so the URI constructor can parse it
+      String str = rawHost.startsWith("http://") || rawHost.startsWith("https://") ? rawHost : "http://" + rawHost;
+
+      URI uri = new URI(str);
+      String host = uri.getHost();
+
+      if (host == null) {
+        log.warning("No host or invalid host specified: '" + rawHost + "'");
+        return Optional.empty();
+      }
+
+      int port = uri.getPort();
+
+      if (port == -1) {
+        return Optional.of(NtHostInfo.onDefaultPort(host));
+      } else {
+        return Optional.of(new NtHostInfo(host, port));
+      }
+    } catch (URISyntaxException e) {
+      log.log(Level.WARNING, "Invalid NetworkTables host: " + rawHost, e);
+      return Optional.empty();
+    }
+  }
+
+}


### PR DESCRIPTION
Backports the HostParser from Shuffleboard.
Supports `team-number`, `host`, `host:port`.
Still asks for team number on startup.

If there is something wrong in how this is done, feel free to say so.
If I've missed some Java nuance my apologies, I've never used it before.