### PR TITLE
synchronously clear all plots for quicker data gathering

### DIFF
--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardMenu.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardMenu.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.smartdashboard.gui;
 
+import edu.wpi.first.smartdashboard.gui.elements.LinePlot;
 import edu.wpi.first.smartdashboard.livewindow.elements.Controller;
 import edu.wpi.first.smartdashboard.livewindow.elements.LWSubsystem;
 import edu.wpi.first.smartdashboard.robot.Robot;
@@ -142,6 +143,20 @@ public class DashboardMenu extends JMenuBar {
         KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK));
     editSystems.doClick();
     viewMenu.add(editSystems);
+
+    final JMenuItem clearPlots = new JMenuItem("Clear All Plots");
+    clearPlots.addActionListener(new ActionListener() {
+      public void actionPerformed(ActionEvent e) {
+        for (Widget component : MainPanel.getCurrentPanel().getWidgets()) {
+          if (component instanceof LinePlot) {
+            ((LinePlot)component).clearPlot();
+            ((LinePlot)component).updateChartRange();
+          }
+        }
+      }
+    });
+    clearPlots.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, KeyEvent.SHIFT_DOWN_MASK));
+    viewMenu.add(clearPlots);
 
     final JMenuItem resetLW = new JMenuItem("Reset LiveWindow");
     resetLW.addActionListener(new ActionListener() {

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
@@ -159,6 +159,13 @@ public class DashboardPanel extends JPanel {
   }
 
   /**
+   * Returns all the {@link Widget Widgets} that are currently being displayed.
+   */
+  public Iterable<Widget> getWidgets() {
+    return fields.values();
+  }
+
+  /**
    * Takes the given value and manipulates it based on the given type to be
    * able to be handed to a {@link Widget}. Basically, if the type is a
    * primitive, the value will be returned. If the type is a

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/LinePlot.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/LinePlot.java
@@ -88,9 +88,8 @@ public class LinePlot extends AbstractValueWidget {
     }
     if (property == clear) {
       if (clear.getValue()) {
-        m_data.clear();
+        clearPlot();
         clear.setValue(false);
-        startTime = System.currentTimeMillis() / 1000.0;
       }
     }
 
@@ -111,5 +110,10 @@ public class LinePlot extends AbstractValueWidget {
     } else {
       m_chart.getXYPlot().getRangeAxis().setRange(minY.getValue(), maxY.getValue());
     }
+  }
+
+  public void clearPlot() {
+    m_data.clear();
+    startTime = System.currentTimeMillis() / 1000.0;
   }
 }


### PR DESCRIPTION
Our team found it time-consuming to clear all plots manually when creating screengrabs of multiple graphs. Additionally it was difficult to get the graphs in a synced timescale when sensor data was actively coming in. This commit introduces a shortcut to perform the clearing action on all the graphs in the window at the same time for quicker and cleaner graph data.