### PR TITLE
Update SmartDashboard to use WPILib-2023.4.3 NetworkTable APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ plugins {
     id 'java'
     id 'application'
     id 'com.github.johnrengelman.shadow' version '7.1.1'
-    id "com.jfrog.artifactory" version "4.16.0"
+    id "com.jfrog.artifactory" version "4.25.2"
     id "com.diffplug.spotless" version "6.0.5"
-    id "com.github.spotbugs" version "5.0.3"
+    id "com.github.spotbugs" version "5.0.4"
     id 'maven-publish'
     id 'idea'
     id 'jacoco'
@@ -20,7 +20,7 @@ plugins {
     id 'edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin' version '4.1.0'
     id 'edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin' version '2020.2'
     id 'checkstyle'
-    id 'edu.wpi.first.WpilibTools' version '0.9.1'
+    id 'edu.wpi.first.WpilibTools' version '1.0.0'
 }
 
 wpilibVersioning.buildServerMode = project.hasProperty('buildServer')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ def nativeTasks = wpilibTools.createExtractionTasks {
 
 nativeTasks.addToSourceSetResources(sourceSets.main)
 
-wpilibTools.deps.wpilibVersion = "2021.3.1"
+wpilibTools.deps.wpilibVersion = "2023.4.3-1-g663703d"
 
 nativeConfig.dependencies.add wpilibTools.deps.wpilib("ntcore")
 nativeConfig.dependencies.add wpilibTools.deps.wpilib("wpiutil")

--- a/fakeRobot/src/main/java/edu/wpi/livewindowfakerobot/LiveWindowFakeRobot.java
+++ b/fakeRobot/src/main/java/edu/wpi/livewindowfakerobot/LiveWindowFakeRobot.java
@@ -1,8 +1,8 @@
 package edu.wpi.livewindowfakerobot;
 
 import edu.wpi.first.networktables.NetworkTablesJNI;
-import edu.wpi.first.wpilibj.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.tables.ITable;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpiutil.CombinedRuntimeLoader;
 import edu.wpi.first.wpiutil.WPIUtilJNI;
 
@@ -16,9 +16,9 @@ import java.util.TimerTask;
  */
 public class LiveWindowFakeRobot {
     
-    private static final NetworkTable liveWindow = NetworkTable.getTable("LiveWindow");
+    private static final NetworkTable liveWindow = NetworkTableInstance.getDefault().getTable("LiveWindow");
     
-    private static final ITable STATUS          = createTable(liveWindow, ".status", "LW Status"),
+    private static final NetworkTable STATUS          = createTable(liveWindow, ".status", "LW Status"),
             
                                 wrist           = createTable(liveWindow, "Wrist", "LW Subsystem"),
                                 wPotentiometer  = createTable(wrist, "Potentiometer", "Analog Input"),
@@ -55,49 +55,49 @@ public class LiveWindowFakeRobot {
         
         System.out.println();
         
-        STATUS.putBoolean("LW Enabled", true);
-        STATUS.putString("Robot", "Testing");
-        wPotentiometer.putNumber("Value", 2.6);
-        ePotentiometer.putNumber("Value", -11.6872);
-        tSwitch.putString("Value", "Off");
+        STATUS.getEntry("LW Enabled").setBoolean(true);
+        STATUS.getEntry("Robot").setString("Testing");
+        wPotentiometer.getEntry("Value").setDouble(2.6);
+        ePotentiometer.getEntry("Value").setDouble(-11.6872);
+        tSwitch.getEntry("Value").setString("Off");
         
-        elevator.putNumber("p", 0.5);
-        elevator.putNumber("i", 0.5);
-        elevator.putNumber("d", 0.5);
-        elevator.putNumber("f", 0.5);
-        elevator.putNumber("setpoint", 0.5);
-        elevator.putBoolean("enabled", false);
+        elevator.getEntry("p").setDouble(0.5);
+        elevator.getEntry("i").setDouble(0.5);
+        elevator.getEntry("d").setDouble(0.5);
+        elevator.getEntry("f").setDouble(0.5);
+        elevator.getEntry("setpoint").setDouble(0.5);
+        elevator.getEntry("enabled").setBoolean(false);
         
-        canJag.putString("Type", "CANJaguar");
-        canTalon.putString("Type", "CANTalon");
+        canJag.getEntry("Type").setString("CANJaguar");
+        canTalon.getEntry("Type").setString("CANTalon");
         
         
         (new Timer()).schedule(
             new TimerTask(){
                 @Override
                 public void run() {
-                    wPotentiometer.putNumber("Value", (Math.random()-.5) * 24);
-                    ePotentiometer.putNumber("Value", (Math.random()-.5) * 24);
-                    tPotentiometer.putNumber("Value", (Math.random()-.5) * 24);
-                    tGyro.putNumber("Value", Math.random() * 360);
-                    tAccel.putNumber("Value", (Math.random()-.5)*8);
-                    tSwitch.putString("Value", Math.random() < 0.5 ? "On" : "Off");
-                    tEncoder1.putNumber("Speed", Math.random() * 20);
-                    tEncoder1.putNumber("Distance", Math.random() * 10);
-                    tEncoder1.putNumber("Distance per Tick", Math.random());
-                    tCompass.putNumber("Value", Math.random());
-                    tUltra.putNumber("Value", (Math.random()-.5) * 200);
-                    tGearTooth.putNumber("Value", (int)(Math.random() * 100));
+                    wPotentiometer.getEntry("Value").setDouble((Math.random()-.5) * 24);
+                    ePotentiometer.getEntry("Value").setDouble((Math.random()-.5) * 24);
+                    tPotentiometer.getEntry("Value").setDouble((Math.random()-.5) * 24);
+                    tGyro.getEntry("Value").setDouble(Math.random() * 360);
+                    tAccel.getEntry("Value").setDouble((Math.random()-.5)*8);
+                    tSwitch.getEntry("Value").setString(Math.random() < 0.5 ? "On" : "Off");
+                    tEncoder1.getEntry("Speed").setDouble(Math.random() * 20);
+                    tEncoder1.getEntry("Distance").setDouble(Math.random() * 10);
+                    tEncoder1.getEntry("Distance per Tick").setDouble(Math.random());
+                    tCompass.getEntry("Value").setDouble(Math.random());
+                    tUltra.getEntry("Value").setDouble((Math.random()-.5) * 200);
+                    tGearTooth.getEntry("Value").setDouble((int)(Math.random() * 100));
                 }}, 
             0, 500);
         
     }
     
-    private static ITable createTable(ITable parent, String name, String type) {
-        ITable table = parent.getSubTable(name);
+    private static NetworkTable createTable(NetworkTable parent, String name, String type) {
+        NetworkTable table = parent.getSubTable(name);
         System.out.println(table);
-        table.putString(".type", type);
-        table.putString("Name", name);
+        table.getEntry(".type").setValue(type);
+        table.getEntry("Name").setValue(name);
         return table;
     }
 }

--- a/src/main/java/edu/wpi/first/smartdashboard/LogToCSV.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/LogToCSV.java
@@ -80,7 +80,7 @@ public class LogToCSV implements TableEntryListener {
     if (m_fw != null) {
       try {
         long timeStamp = System.currentTimeMillis() - m_startTime;
-        m_fw.write(timeStamp + "," + "\"" + key + "\"," + "\"" + value + "\"" + s_lineSeparator);
+        m_fw.write(timeStamp + "," + "\"" + key + "\"," + "\"" + value.getValue() + "\"" + s_lineSeparator);
         m_fw.flush();
       } catch (IOException ex) {
         ex.printStackTrace();

--- a/src/main/java/edu/wpi/first/smartdashboard/SmartDashboard.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/SmartDashboard.java
@@ -3,7 +3,6 @@ package edu.wpi.first.smartdashboard;
 import edu.wpi.first.networktables.NetworkTablesJNI;
 import edu.wpi.first.smartdashboard.extensions.FileSniffer;
 import edu.wpi.first.smartdashboard.gui.DashboardFrame;
-import edu.wpi.first.smartdashboard.properties.IntegerProperty;
 import edu.wpi.first.smartdashboard.properties.StringProperty;
 import edu.wpi.first.smartdashboard.robot.Robot;
 import edu.wpi.first.wpiutil.CombinedRuntimeLoader;

--- a/src/main/java/edu/wpi/first/smartdashboard/SmartDashboard.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/SmartDashboard.java
@@ -5,8 +5,8 @@ import edu.wpi.first.smartdashboard.extensions.FileSniffer;
 import edu.wpi.first.smartdashboard.gui.DashboardFrame;
 import edu.wpi.first.smartdashboard.properties.StringProperty;
 import edu.wpi.first.smartdashboard.robot.Robot;
-import edu.wpi.first.wpiutil.CombinedRuntimeLoader;
-import edu.wpi.first.wpiutil.WPIUtilJNI;
+import edu.wpi.first.util.CombinedRuntimeLoader;
+import edu.wpi.first.util.WPIUtilJNI;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/edu/wpi/first/smartdashboard/extensions/FileSniffer.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/extensions/FileSniffer.java
@@ -93,49 +93,53 @@ public class FileSniffer {
       try {
         classLoader.addURL(file.toURI().toURL());
         JarFile jarFile = new JarFile(file);
-        Enumeration<JarEntry> entries = jarFile.entries();
-        while (entries.hasMoreElements()) {
-          JarEntry entry = entries.nextElement();
-          if (entry.isDirectory()) {
-            continue;
-          }
-          if (entry.getName().endsWith(".class")) {
-            try {
-              String className = entry.getName();
-              className = className.substring(0, className.length() - 6);
-              className = className.replace('/', '.');
-              Class<?> clazz = classLoader.loadClass(className);
-              if (Widget.class.isAssignableFrom(clazz)) {
-                System.out.println("Custom Widget Loaded: " + clazz.getSimpleName());
-                DisplayElementRegistry.registerWidget(clazz.asSubclass(Widget.class));
-              } else if (StaticWidget.class.isAssignableFrom(clazz)) {
-                System.out.println("Custom Static Widget Loaded: " + clazz.getSimpleName());
-                DisplayElementRegistry.registerStaticWidget(clazz.asSubclass(StaticWidget.class));
-              } else if (NamedDataType.class.isAssignableFrom(clazz)) {
-                try {
-                  Object ret = clazz.asSubclass(NamedDataType.class).getMethod("get").invoke(null);
-                  if (ret == null) {
-                    System.out.println(
-                        "ERROR: custom named data type " + clazz.getSimpleName()
-                        + " failed to load"
-                    );
-                  } else {
-                    System.out.println("Custom Named Data Type Loaded: " + clazz.getSimpleName());
+        try {
+          Enumeration<JarEntry> entries = jarFile.entries();
+          while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            if (entry.isDirectory()) {
+              continue;
+            }
+            if (entry.getName().endsWith(".class")) {
+              try {
+                String className = entry.getName();
+                className = className.substring(0, className.length() - 6);
+                className = className.replace('/', '.');
+                Class<?> clazz = classLoader.loadClass(className);
+                if (Widget.class.isAssignableFrom(clazz)) {
+                  System.out.println("Custom Widget Loaded: " + clazz.getSimpleName());
+                  DisplayElementRegistry.registerWidget(clazz.asSubclass(Widget.class));
+                } else if (StaticWidget.class.isAssignableFrom(clazz)) {
+                  System.out.println("Custom Static Widget Loaded: " + clazz.getSimpleName());
+                  DisplayElementRegistry.registerStaticWidget(clazz.asSubclass(StaticWidget.class));
+                } else if (NamedDataType.class.isAssignableFrom(clazz)) {
+                  try {
+                    Object ret = clazz.asSubclass(NamedDataType.class).getMethod("get").invoke(null);
+                    if (ret == null) {
+                      System.out.println(
+                          "ERROR: custom named data type " + clazz.getSimpleName()
+                          + " failed to load"
+                      );
+                    } else {
+                      System.out.println("Custom Named Data Type Loaded: " + clazz.getSimpleName());
+                    }
+                  } catch (Exception e) {
+                    e.printStackTrace();
                   }
-                } catch (Exception e) {
-                  e.printStackTrace();
                 }
+              } catch (ClassNotFoundException e) {
+                e.printStackTrace();
               }
-            } catch (ClassNotFoundException e) {
-              e.printStackTrace();
             }
           }
-        }
-      } catch (MalformedURLException e) {
-        e.printStackTrace();
-      } catch (IOException e) {
-        e.printStackTrace();
+        } finally {jarFile.close();}
       }
+      catch (MalformedURLException e) {
+        e.printStackTrace();
+      } 
+      catch (IOException e) {
+        e.printStackTrace();
+      } 
     }
 
     monitor.setProgress(max);

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.smartdashboard.gui;
 
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.smartdashboard.LogToCSV;
 import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.livewindow.elements.LWSubsystem;
@@ -102,17 +103,17 @@ public class DashboardFrame extends JFrame {
    */
   public DashboardFrame(boolean competition) {
     setTitle(TITLE + "Disconnected");
-    NetworkTableInstance.getDefault().addConnectionListener((event) -> {
+    NetworkTableInstance.getDefault().addConnectionListener(true, (event) -> {
       String newTitle;
-      if ((event.getInstance().getNetworkMode() & NetworkTableInstance.kNetModeServer) != 0) {
+      if ((event.getInstance().getNetworkMode().contains(NetworkTableInstance.NetworkMode.kServer))) {
         newTitle = TITLE + "Number of Clients: " + event.getInstance().getConnections().length;
-      } else if (event.connected && event.conn != null) {
-        newTitle = TITLE + "Connected: " + event.conn.remote_ip;
+      } else if (event.is(NetworkTableEvent.Kind.kConnected) && event.connInfo != null) {
+        newTitle = TITLE + "Connected: " + event.connInfo.remote_ip;
       } else {
         newTitle = TITLE + "Disconnected";
       }
       SwingUtilities.invokeLater(() -> setTitle(newTitle));
-    }, true);
+    });
 
     setLayout(new BorderLayout());
 

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
@@ -84,7 +84,8 @@ public class DashboardFrame extends JFrame {
   private boolean shouldHideMenu = prefs.hideMenu.getValue();
 
   private static final String LW_SAVE = "_"
-      + Robot.getLiveWindow().getSubTable(".status").getString("Robot", "LiveWindow") + ".xml";
+      + Robot.getLiveWindow().getSubTable(".status")
+      .getEntry("Robot").getString("LiveWindow") + ".xml";
 
   private final LogToCSV logger = new LogToCSV(this);
 
@@ -346,7 +347,7 @@ public class DashboardFrame extends JFrame {
           Widget e = (Widget) element;
           Object value = null;
           if (Robot.getTable().containsKey(e.getFieldName())) {
-            value = Robot.getTable().getValue(e.getFieldName(), null);
+            value = Robot.getTable().getEntry(e.getFieldName()).getValue();
             DataType type = DataType.getType(value);
             if (DisplayElementRegistry.supportsType(e.getClass(), type)) {
               smartDashboardPanel.setField(e.getFieldName(), e, type, value, e.getSavedLocation());
@@ -370,7 +371,7 @@ public class DashboardFrame extends JFrame {
         mostRecentParent = subsystem;
         Object value1 = null;
         if (Robot.getLiveWindow().containsKey(subsystem.getFieldName())) {
-          value1 = Robot.getTable().getValue(subsystem.getFieldName(), null);
+          value1 = Robot.getTable().getEntry(subsystem.getFieldName()).getValue();
           DataType type = DataType.getType(value1);
           if (DisplayElementRegistry.supportsType(subsystem.getClass(), type)) {
             liveWindowPanel.setField(subsystem.getFieldName(), subsystem, type, value1, subsystem

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardFrame.java
@@ -347,7 +347,7 @@ public class DashboardFrame extends JFrame {
           Widget e = (Widget) element;
           Object value = null;
           if (Robot.getTable().containsKey(e.getFieldName())) {
-            value = Robot.getTable().getEntry(e.getFieldName()).getValue();
+            value = Robot.getTable().getEntry(e.getFieldName()).getValue().getValue();
             DataType type = DataType.getType(value);
             if (DisplayElementRegistry.supportsType(e.getClass(), type)) {
               smartDashboardPanel.setField(e.getFieldName(), e, type, value, e.getSavedLocation());

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardMenu.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardMenu.java
@@ -5,15 +5,17 @@ import edu.wpi.first.smartdashboard.livewindow.elements.Controller;
 import edu.wpi.first.smartdashboard.livewindow.elements.LWSubsystem;
 import edu.wpi.first.smartdashboard.robot.Robot;
 import edu.wpi.first.smartdashboard.types.DisplayElementRegistry;
-import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.networktables.NetworkTableValue;
-import edu.wpi.first.networktables.TableEntryListener;
+
+import edu.wpi.first.networktables.NetworkTableEvent;
+
+import edu.wpi.first.networktables.NetworkTable.TableEventListener;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.io.File;
+import java.util.EnumSet;
 import java.util.Set;
 import javax.swing.AbstractAction;
 import javax.swing.JCheckBoxMenuItem;
@@ -175,9 +177,11 @@ public class DashboardMenu extends JMenuBar {
       }
     });
     resetLW.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, KeyEvent.CTRL_DOWN_MASK));
-    Robot.getLiveWindow().getSubTable(".status").addEntryListener("LW Enabled", new
-        TableEntryListener() {
-      public void valueChanged(NetworkTable table, String string, NetworkTableEntry e, NetworkTableValue v, int flags) {
+    Robot.getLiveWindow().getSubTable(".status").addListener("LW Enabled", 
+      EnumSet.of(NetworkTableEvent.Kind.kValueAll),
+      new
+        TableEventListener() {
+      public void accept(NetworkTable table, String string, NetworkTableEvent e) {
         final boolean isInLW
             = Robot.getLiveWindow().getSubTable(".status").getEntry("LW Enabled").getBoolean(false);
 
@@ -197,8 +201,7 @@ public class DashboardMenu extends JMenuBar {
           }
         });
       }
-    }, EntryListenerFlags.kImmediate | EntryListenerFlags.kLocal | EntryListenerFlags.kNew
-       | EntryListenerFlags.kUpdate);
+    });
     viewMenu.add(resetLW);
 
     JMenu addMenu = new JMenu("Add...");

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardMenu.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardMenu.java
@@ -5,8 +5,11 @@ import edu.wpi.first.smartdashboard.livewindow.elements.Controller;
 import edu.wpi.first.smartdashboard.livewindow.elements.LWSubsystem;
 import edu.wpi.first.smartdashboard.robot.Robot;
 import edu.wpi.first.smartdashboard.types.DisplayElementRegistry;
-import edu.wpi.first.wpilibj.tables.ITable;
-import edu.wpi.first.wpilibj.tables.ITableListener;
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.networktables.TableEntryListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -63,7 +66,7 @@ public class DashboardMenu extends JMenuBar {
     newMenu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, KeyEvent.CTRL_DOWN_MASK));
     newMenu.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
-        mainPanel.getPanel("SmartDashboard").clear();
+        MainPanel.getPanel("SmartDashboard").clear();
       }
     });
     fileMenu.add(newMenu);
@@ -172,11 +175,11 @@ public class DashboardMenu extends JMenuBar {
       }
     });
     resetLW.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, KeyEvent.CTRL_DOWN_MASK));
-    Robot.getLiveWindow().getSubTable(".status").addTableListenerEx("LW Enabled", new
-        ITableListener() {
-      public void valueChanged(ITable itable, String string, Object o, boolean bln) {
+    Robot.getLiveWindow().getSubTable(".status").addEntryListener("LW Enabled", new
+        TableEntryListener() {
+      public void valueChanged(NetworkTable table, String string, NetworkTableEntry e, NetworkTableValue v, int flags) {
         final boolean isInLW
-            = Robot.getLiveWindow().getSubTable(".status").getBoolean("LW Enabled", false);
+            = Robot.getLiveWindow().getSubTable(".status").getEntry("LW Enabled").getBoolean(false);
 
         SwingUtilities.invokeLater(new Runnable() {
           public void run() {
@@ -194,7 +197,8 @@ public class DashboardMenu extends JMenuBar {
           }
         });
       }
-    }, ITable.NOTIFY_IMMEDIATE | ITable.NOTIFY_LOCAL | ITable.NOTIFY_NEW | ITable.NOTIFY_UPDATE);
+    }, EntryListenerFlags.kImmediate | EntryListenerFlags.kLocal | EntryListenerFlags.kNew
+       | EntryListenerFlags.kUpdate);
     viewMenu.add(resetLW);
 
     JMenu addMenu = new JMenu("Add...");
@@ -204,8 +208,9 @@ public class DashboardMenu extends JMenuBar {
       item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           try {
+            @SuppressWarnings("deprecation")
             StaticWidget element = option.newInstance();
-            mainPanel.getPanel("SmartDashboard").addElement(element, null);
+            MainPanel.getPanel("SmartDashboard").addElement(element, null);
           } catch (InstantiationException ex) {
             // TODO
           } catch (IllegalAccessException ex) {
@@ -226,12 +231,12 @@ public class DashboardMenu extends JMenuBar {
         revealMenu.removeAll();
 
         int count = 0;
-        for (final String field : mainPanel.getPanel("SmartDashboard").getHiddenFields()) {
-          if (mainPanel.getPanel("SmartDashboard").getTable().containsKey(field)) {
+        for (final String field : MainPanel.getPanel("SmartDashboard").getHiddenFields()) {
+          if (MainPanel.getPanel("SmartDashboard").getTable().containsKey(field)) {
             count++;
             revealMenu.add(new JMenuItem(new AbstractAction(field) {
               public void actionPerformed(ActionEvent e) {
-                mainPanel.getPanel("SmartDashboard").addField(field);
+                MainPanel.getPanel("SmartDashboard").addField(field);
               }
             }));
           }

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
@@ -555,7 +555,7 @@ public class DashboardPanel extends JPanel {
         if (!hiddenFields.contains(key)) {
             SwingUtilities.invokeLater(new Runnable() {
               public void run() {
-                setField(key, null, value, null);
+                setField(key, null, value.getValue(), null);
               }
             });
         }

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
@@ -146,7 +146,7 @@ public class DashboardPanel extends JPanel {
 
   /**
    * Returns the names of all the fields marked as hidden (they are the ones
-   * in the {@link ITable} that have been explicitly declared to be ignored by
+   * in the {@link NetworkTable} that have been explicitly declared to be ignored by
    * the user).
    *
    * @return the hidden fields

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/DashboardPanel.java
@@ -590,7 +590,7 @@ public class DashboardPanel extends JPanel {
           public void setHandle(int handle) { myHandle = handle; }
         };
         TEListenerWithHandle teListener = new TEListenerWithHandle();
-        teListener.setHandle(table.addEntryListener(".type", teListener, 
+        teListener.setHandle(newTable.addEntryListener(".type", teListener, 
           EntryListenerFlags.kImmediate            
           | EntryListenerFlags.kLocal | EntryListenerFlags.kNew
           | EntryListenerFlags.kUpdate));

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/GlassPane.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/GlassPane.java
@@ -519,7 +519,7 @@ public class GlassPane extends JPanel {
         Widget oldElement = (Widget) menuElement;
 
         if (panel.getTable().containsKey(oldElement.getFieldName())) {
-          Object value = panel.getTable().getEntry(oldElement.getFieldName()).getValue();
+          Object value = panel.getTable().getEntry(oldElement.getFieldName()).getValue().getValue();
           panel.setField(oldElement.getFieldName(), elementClass, value, oldElement.getLocation());
         } else {
           panel.setField(oldElement.getFieldName(), elementClass, oldElement.getType(), null,

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/GlassPane.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/GlassPane.java
@@ -519,7 +519,7 @@ public class GlassPane extends JPanel {
         Widget oldElement = (Widget) menuElement;
 
         if (panel.getTable().containsKey(oldElement.getFieldName())) {
-          Object value = panel.getTable().getValue(oldElement.getFieldName(), null);
+          Object value = panel.getTable().getEntry(oldElement.getFieldName()).getValue();
           panel.setField(oldElement.getFieldName(), elementClass, value, oldElement.getLocation());
         } else {
           panel.setField(oldElement.getFieldName(), elementClass, oldElement.getType(), null,

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/MainPanel.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/MainPanel.java
@@ -17,7 +17,7 @@ import javax.swing.JPanel;
  */
 public final class MainPanel extends JPanel {
 
-  public static final HashMap<String, DashboardPanel> panels = new HashMap();
+  public static final HashMap<String, DashboardPanel> panels = new HashMap<String, DashboardPanel>();
   private static DashboardPanel currentPanel;
 
   public MainPanel(LayoutManager layout, DashboardPanel defaultPanel, DashboardPanel... panels) {

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/Widget.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/Widget.java
@@ -1,11 +1,11 @@
 package edu.wpi.first.smartdashboard.gui;
 
+import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.smartdashboard.gui.elements.bindings.BooleanBindable;
 import edu.wpi.first.smartdashboard.gui.elements.bindings.NumberBindable;
 import edu.wpi.first.smartdashboard.gui.elements.bindings.StringBindable;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.DisplayElementRegistry;
-import edu.wpi.first.wpilibj.tables.ITable;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentEvent;
@@ -523,27 +523,27 @@ public abstract class Widget extends DisplayElement {
   public static class BindableTableEntry implements BooleanBindable, NumberBindable,
       StringBindable {
 
-    private final ITable table;
+    private final NetworkTable table;
     private final String key;
 
-    public BindableTableEntry(ITable table, String key) {
+    public BindableTableEntry(NetworkTable table, String key) {
       this.table = table;
       this.key = key;
     }
 
     @Override
     public void setBindableValue(String value) {
-      table.putString(key, value);
+      table.getEntry(key).setString(value);
     }
 
     @Override
     public void setBindableValue(double value) {
-      table.putNumber(key, value);
+      table.getEntry(key).setDouble(value);
     }
 
     @Override
     public void setBindableValue(boolean value) {
-      table.putBoolean(key, value);
+      table.getEntry(key).setValue(value);
     }
   }
 

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Button.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Button.java
@@ -23,12 +23,12 @@ public class Button extends AbstractTableWidget {
     start.addMouseListener(new MouseAdapter() {
       @Override
       public void mousePressed(MouseEvent e) {
-        table.putBoolean("pressed", true);
+        table.getEntry("pressed").setBoolean(true);
       }
 
       @Override
       public void mouseReleased(MouseEvent e) {
-        table.putBoolean("pressed", false);
+        table.getEntry("pressed").setBoolean(false);
       }
     });
 

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/CameraServerViewer.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/CameraServerViewer.java
@@ -3,9 +3,10 @@ package edu.wpi.first.smartdashboard.gui.elements;
 import edu.wpi.first.smartdashboard.properties.MultiProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.properties.StringProperty;
-import edu.wpi.first.wpilibj.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.tables.ITable;
-import edu.wpi.first.wpilibj.tables.ITableListener;
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.TableEntryListener;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -19,35 +20,41 @@ public class CameraServerViewer extends MjpgStreamViewer {
   public final StringProperty selectedCameraPathProperty
       = new StringProperty(this, "Selected Camera Path", "");
 
-  private ITable cameraTable;
-  private ITable rootTable = NetworkTable.getTable("");
-  private ITableListener selectedCameraPathListener
-      = (source, key, value, isNew) -> cameraProperty.setValue(value);
+  private NetworkTable cameraTable;
+  private NetworkTable rootTable = NetworkTableInstance.getDefault().getTable("");
+  private TableEntryListener selectedCameraPathListener
+      = (source, key, entry, value, flags) -> cameraProperty.setValue(value);
+  private int listenerHandle;
 
   @Override
   public void onInit() {
-    NetworkTable.getTable("CameraPublisher").addSubTableListener(((source, key, value, isNew) -> {
-      cameraProperty.add(key, value);
-      if (cameraTable == null
-          && (cameraProperty.getSavedValue().isEmpty()
-          || key.equals(cameraProperty.getSavedValue()))) {
-        cameraTable = (ITable) value;
-      }
-    }));
+    rootTable.getSubTable("CameraPublisher").addSubTableListener(
+      ((NetworkTable source, String key, NetworkTable subtable) -> {
+        cameraProperty.add(key, subtable);
+        if (cameraTable == null
+            && (cameraProperty.getSavedValue().isEmpty()
+            || key.equals(cameraProperty.getSavedValue()))) {
+          cameraTable = subtable;
+        }
+      }), true
+    );
 
-    rootTable.addTableListener(selectedCameraPathProperty.getValue(),
-        selectedCameraPathListener, true);
-  }
+    listenerHandle = rootTable.addEntryListener(selectedCameraPathProperty.getValue(),
+        selectedCameraPathListener, EntryListenerFlags.kLocal | EntryListenerFlags.kImmediate 
+        | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
+  }  
 
   @Override
   public void onPropertyChanged(Property property) {
     if (property == cameraProperty) {
-      cameraTable = (ITable) cameraProperty.getValue();
+      cameraTable = (NetworkTable) cameraProperty.getValue();
       cameraChanged();
     } else if (property == selectedCameraPathProperty) {
-      rootTable.removeTableListener(selectedCameraPathListener);
-      rootTable.addTableListener(selectedCameraPathProperty.getValue(),
-          selectedCameraPathListener, true);
+      rootTable.removeTableListener(listenerHandle);
+      listenerHandle = rootTable.addEntryListener(selectedCameraPathProperty.getValue(),
+          selectedCameraPathListener, 
+          EntryListenerFlags.kLocal | EntryListenerFlags.kImmediate 
+        | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
     }
   }
 
@@ -57,9 +64,10 @@ public class CameraServerViewer extends MjpgStreamViewer {
       return Stream.empty();
     }
 
-    return Arrays.stream(cameraTable.getStringArray(STREAMS_KEY, new String[0])).map(s -> {
-      if (NetworkTable.connections().length > 0) {
-        return s.replaceFirst("roboRIO-\\d+-FRC.*(?=:)", NetworkTable.connections()[0].remote_ip);
+    return Arrays.stream(cameraTable.getEntry(STREAMS_KEY).getStringArray(new String[0])).map(s -> {
+      if (NetworkTableInstance.getDefault().getConnections().length > 0) {
+        return s.replaceFirst("roboRIO-\\d+-FRC.*(?=:)", 
+                              NetworkTableInstance.getDefault().getConnections()[0].remote_ip);
       }
       return s;
     });

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
@@ -1,8 +1,7 @@
 package edu.wpi.first.smartdashboard.gui.elements;
 
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.properties.BooleanProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
@@ -54,8 +53,7 @@ public class Chooser extends AbstractTableWidget {
   }
 
   @Override
-  public void valueChanged(NetworkTable source, String key, NetworkTableEntry entry,
-                           NetworkTableValue value, int flags) {
+  public void accept(NetworkTable source, String key, NetworkTableEvent event) {
     if (key.equals(OPTIONS)) {
       choices = Arrays.asList(table.getEntry(OPTIONS).getStringArray(new String[]{}));
       display.setChoices(choices);

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Chooser.java
@@ -1,12 +1,13 @@
 package edu.wpi.first.smartdashboard.gui.elements;
 
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableValue;
 import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.properties.BooleanProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.StringChooserType;
-import edu.wpi.first.wpilibj.tables.ITable;
-import edu.wpi.first.wpilibj.tables.ITableListener;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -26,7 +27,7 @@ import javax.swing.JRadioButton;
 /**
  * @author Joe Grinstead
  */
-public class Chooser extends AbstractTableWidget implements ITableListener {
+public class Chooser extends AbstractTableWidget {
 
   private static final String DEFAULT = "default";
   private static final String SELECTED = "selected";
@@ -53,19 +54,20 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
   }
 
   @Override
-  public void valueChanged(ITable source, String key, Object value, boolean isNew) {
+  public void valueChanged(NetworkTable source, String key, NetworkTableEntry entry,
+                           NetworkTableValue value, int flags) {
     if (key.equals(OPTIONS)) {
-      choices = Arrays.asList(table.getStringArray(OPTIONS, new String[]{}));
+      choices = Arrays.asList(table.getEntry(OPTIONS).getStringArray(new String[]{}));
       display.setChoices(choices);
     }
     //if(key.equals(DEFAULT))
     //    display.setDefault(source.getString(DEFAULT)); //TODO handle change in default?
     if (key.equals(SELECTED)) {
-      display.setSelected(source.getString(SELECTED, ""));
+      display.setSelected(source.getEntry(SELECTED).getString(""));
     }
 
     if (!source.containsKey(SELECTED)) {
-      source.putString(SELECTED, source.getString(DEFAULT, choices.get(0)));
+      source.getEntry(SELECTED).setString(source.getEntry(DEFAULT).getString(choices.get(0)));
     }
   }
 
@@ -159,16 +161,16 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
       }
 
       if (table != null && selection != null) {
-        table.putString(SELECTED, selection);
+        table.getEntry(SELECTED).setString(selection);
         if (buttons.get(selection) != null) {
           selected = buttons.get(selection);
           selected.setSelected(true);
         }
       } else {
         if (table != null && table.containsKey(DEFAULT)
-            && !table.getString(DEFAULT, "").equals("")) {
-          selection = table.getString(DEFAULT, "");
-          selected = buttons.get(table.getString(DEFAULT, ""));
+            && !table.getEntry(DEFAULT).getString("").equals("")) {
+          selection = table.getEntry(DEFAULT).getString("");
+          selected = buttons.get(table.getEntry(DEFAULT).getString(""));
           selected.setSelected(true);
         } else {
           selected = null;
@@ -198,14 +200,14 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
       String userChoice = e.getActionCommand();
       if (selection == null || !selection.equals(userChoice)) {
         selection = userChoice;
-        table.putString(SELECTED, selection);
+        table.getEntry(SELECTED).setString(selection);
       }
     }
   }
 
   private class ComboBox extends Display implements ItemListener {
 
-    JComboBox combo;
+    JComboBox<String> combo;
 
     @Override
     void setEditable(boolean editable) {
@@ -221,7 +223,7 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
         combo.removeItemListener(this);
       }
 
-      combo = new JComboBox();
+      combo = new JComboBox<String>();
 
       boolean hasSelection = false;
 
@@ -236,15 +238,15 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
       }
 
       if (table != null && table.containsKey(SELECTED)) {
-        selection = table.getString(SELECTED, "");
+        selection = table.getEntry(SELECTED).getString("");
       }
 
       if (table != null && selection != null) {
         combo.setSelectedItem(selection);
-        table.putString(SELECTED, selection);
+        table.getEntry(SELECTED).setString(selection);
       } else {
         if (table != null && table.containsKey(DEFAULT)) {
-          combo.setSelectedItem(table.getString(DEFAULT, ""));
+          combo.setSelectedItem(table.getEntry(DEFAULT).getString(""));
         }
       }
 
@@ -272,7 +274,7 @@ public class Chooser extends AbstractTableWidget implements ITableListener {
         String userChoice = (String) e.getItem();
         if (!userChoice.equals(selection)) {
           selection = userChoice;
-          table.putString(SELECTED, selection);
+          table.getEntry(SELECTED).setString(selection);
         }
       }
     }

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Command.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Command.java
@@ -5,7 +5,7 @@ import edu.wpi.first.smartdashboard.properties.ColorProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.CommandType;
-import edu.wpi.first.wpilibj.tables.ITable;
+import edu.wpi.first.networktables.NetworkTable;
 import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
@@ -45,7 +45,7 @@ public class Command extends AbstractTableWidget {
     start.addActionListener(new ActionListener() {
 
       public void actionPerformed(ActionEvent e) {
-        table.putBoolean("running", true);
+        table.getEntry("running").setBoolean(true);
       }
     });
     start.setForeground(startBackground.getValue());
@@ -57,7 +57,7 @@ public class Command extends AbstractTableWidget {
     cancel.addActionListener(new ActionListener() {
 
       public void actionPerformed(ActionEvent e) {
-        table.putBoolean("running", false);
+        table.getEntry("running").setBoolean(false);
       }
     });
     cancel.setForeground(cancelBackground.getValue());
@@ -70,7 +70,7 @@ public class Command extends AbstractTableWidget {
   }
 
   @Override
-  public void booleanChanged(ITable source, String key, final boolean value, boolean isNew) {
+  public void booleanChanged(NetworkTable source, String key, final boolean value, boolean isNew) {
     if (key.equals("running")) {
       SwingUtilities.invokeLater(new Runnable() {
         public void run() {

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/CommandButton.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/CommandButton.java
@@ -22,7 +22,7 @@ public class CommandButton extends AbstractTableWidget {
     start.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
-        table.putBoolean("running", true);
+        table.getEntry("running").setBoolean(true);
       }
     });
 

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Compass.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Compass.java
@@ -7,7 +7,7 @@ import edu.wpi.first.smartdashboard.properties.DoubleProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.GyroType;
-import edu.wpi.first.wpilibj.tables.ITable;
+import edu.wpi.first.networktables.NetworkTable;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -53,13 +53,13 @@ public class Compass extends AbstractTableWidget implements NumberBindable {
 
   public void setValue(double value) {
     if (table != null) {
-      setValue((ITable) null);
+      setValue((NetworkTable) null);
     }
     updateValue(value);
   }
 
   @Override
-  public void doubleChanged(ITable source, String key, double value, boolean isNew) {
+  public void doubleChanged(NetworkTable source, String key, double value, boolean isNew) {
     if (key.equals("angle") || key.equals("Value")) {
       updateValue(value);
     }

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/ConnectionIndicator.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/ConnectionIndicator.java
@@ -1,6 +1,6 @@
 package edu.wpi.first.smartdashboard.gui.elements;
 
-import edu.wpi.first.networktables.ConnectionNotification;
+import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.smartdashboard.gui.StaticWidget;
 import edu.wpi.first.smartdashboard.properties.ColorProperty;
 import edu.wpi.first.smartdashboard.properties.MultiProperty;
@@ -16,7 +16,7 @@ import javax.swing.SwingUtilities;
 /**
  * @author Joe Grinstead
  */
-public class ConnectionIndicator extends StaticWidget implements Consumer<ConnectionNotification> {
+public class ConnectionIndicator extends StaticWidget implements Consumer<NetworkTableEvent> {
 
   public static final String NAME = "Connection Indicator";
   private static final int DRAW_EMBOSSED = 0;
@@ -93,8 +93,8 @@ public class ConnectionIndicator extends StaticWidget implements Consumer<Connec
   }
 
   @Override
-  public void accept(ConnectionNotification notification) {
-    if (notification.connected) {
+  public void accept(NetworkTableEvent event) {
+    if (event.is(NetworkTableEvent.Kind.kConnected)) {
       System.out.println("ConnectionIndicator CONNECTED");
       if (!connected) {
         connected = true;

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/ConnectionIndicator.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/ConnectionIndicator.java
@@ -99,12 +99,12 @@ public class ConnectionIndicator extends StaticWidget implements Consumer<Connec
       if (!connected) {
         connected = true;
         SwingUtilities.invokeLater(repainter);
-      } else {
-        System.out.println("ConnectionIndicator DISCONNECTED");
-        if (connected) {
-          connected = false;
-          SwingUtilities.invokeLater(repainter);
-        }
+      } 
+    } else {
+      System.out.println("ConnectionIndicator DISCONNECTED");
+      if (connected) {
+        connected = false;
+        SwingUtilities.invokeLater(repainter);
       }
     }
   }

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/PIDEditor.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/PIDEditor.java
@@ -20,7 +20,6 @@ public class PIDEditor extends AbstractTableWidget implements Controller {
 
   private final boolean editType;
 
-  private NumberTableComboBox tBox;
   private NumberTableField pField;
   private NumberTableField iField;
   private NumberTableField dField;

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/PIDEditor.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/PIDEditor.java
@@ -34,7 +34,7 @@ public class PIDEditor extends AbstractTableWidget implements Controller {
     this(true);
   }
 
-  public PIDEditor(boolean editType) { //TODO alert user when the robot is about reset modified
+  public PIDEditor(boolean editType) { //TODO alert user when the robot is about reset modified ???
     // PID values
     this.editType = editType;
   }

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
@@ -179,7 +179,7 @@ public class RobotPreferences extends StaticWidget implements TableEntryListener
     if ((flags & EntryListenerFlags.kDelete) != 0) {
       values.remove(key);
     } else {
-      values.put(key, ntValue);
+      values.put(key, ntValue.getValue());
     }
 
     if (model != null) {

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/RobotPreferences.java
@@ -145,7 +145,7 @@ public class RobotPreferences extends StaticWidget implements TableEventListener
 
 
     JPanel buttonPanel = new JPanel();
-    buttonPanel.setLayout(new GridLayout(0, 4));
+    buttonPanel.setLayout(new GridLayout(0, 2));
     buttonPanel.add(add);
     buttonPanel.add(remove);
 
@@ -432,7 +432,9 @@ public class RobotPreferences extends StaticWidget implements TableEventListener
     }
 
     public void delete(String key) {
-      Robot.getPreferences().getEntry(key).unpublish();
+      var entry =  Robot.getPreferences().getEntry(key);
+      entry.clearPersistent();
+      entry.unpublish();
     }
 
     public boolean validateKey(String key) {

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Scheduler.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Scheduler.java
@@ -79,9 +79,9 @@ public class Scheduler extends Widget {
                 button.addActionListener(new ActionListener() {
                   public void actionPerformed(ActionEvent e) {
                     // Cancel commands
-                    toCancel = Arrays.asList(table.getEntry("Cancel").getDoubleArray(new Double[0]));
+                    toCancel = new ArrayList<Double>(Arrays.asList(table.getEntry("Cancel").getDoubleArray(new Double[0])));
                     toCancel.add(ids.get(index));
-                    table.getEntry("Cancel").setValue(toCancel);
+                    table.getEntry("Cancel").setValue(toCancel.toArray(new Double[0]));
                   }
                 });
                 buttons.add(button);

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Scheduler.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Scheduler.java
@@ -1,10 +1,8 @@
 package edu.wpi.first.smartdashboard.gui.elements;
 
-import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.networktables.NetworkTableValue;
-import edu.wpi.first.networktables.TableEntryListener;
+import edu.wpi.first.networktables.NetworkTableEvent;
+import edu.wpi.first.networktables.NetworkTable.TableEventListener;
 import edu.wpi.first.smartdashboard.gui.Widget;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
@@ -16,6 +14,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -47,14 +46,13 @@ public class Scheduler extends Widget {
   private List<Double> toCancel = new ArrayList<>();
 
   private int listenerHandle;
-  private TableEntryListener listener = new TableEntryListener() {
+  private TableEventListener listener = new TableEventListener() {
 
     boolean running = false;
 
     @Override
-    public void valueChanged(NetworkTable source, String key, 
-                             NetworkTableEntry entry,
-                             NetworkTableValue value, int flags) {
+    public void accept(NetworkTable source, String key, 
+                             NetworkTableEvent event) {
       if (running) {
         return;
       }
@@ -118,12 +116,13 @@ public class Scheduler extends Widget {
   @Override
   public void setValue(Object value) {
     if (table != null) {
-      table.removeTableListener(listenerHandle);
+      table.removeListener(listenerHandle);
     }
     table = (NetworkTable) value;
-    listenerHandle = table.addEntryListener(listener,
-        EntryListenerFlags.kImmediate | EntryListenerFlags.kLocal 
-      | EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
+    listenerHandle = table.addListener(
+      EnumSet.of(NetworkTableEvent.Kind.kImmediate, NetworkTableEvent.Kind.kPublish,
+                 NetworkTableEvent.Kind.kValueAll),
+                 listener);
 
     revalidate();
     repaint();

--- a/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Subsystem.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/gui/elements/Subsystem.java
@@ -7,14 +7,13 @@ import edu.wpi.first.smartdashboard.properties.ColorProperty;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.SubsystemType;
-import edu.wpi.first.wpilibj.tables.ITableListener;
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 
 /**
  * @author Joe Grinstead
  */
-public class Subsystem extends AbstractTableWidget implements ITableListener {
+public class Subsystem extends AbstractTableWidget {
 
   public static final DataType[] TYPES = {SubsystemType.get()};
 

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/CANSpeedController.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/CANSpeedController.java
@@ -5,7 +5,10 @@ import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.CANSpeedControllerType;
-import edu.wpi.first.wpilibj.tables.ITable;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableValue;
+
 import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -74,9 +77,9 @@ public class CANSpeedController extends AbstractTableWidget implements Controlle
     }
     normalControlPanel.reset();
     mode = m;
-    table.putBoolean("Enabled",
+    table.getEntry("Enabled").setBoolean(
         mode == 0 || mode == 4); // enable on %VBus and voltage, disable on all others
-    table.putNumber("Mode", mode);
+    table.getEntry("Mode").setNumber(mode);
   };
 
   @Override
@@ -130,8 +133,8 @@ public class CANSpeedController extends AbstractTableWidget implements Controlle
     super.setValue(value);
     pidControlPanel.setValue(value);
     normalControlPanel.setValue(value);
-    this.type = table.getString("Type", "[unknown]");
-    this.mode = (int) table.getNumber("Mode", 0);
+    this.type = table.getEntry("Type").getString("[unknown]");
+    this.mode = (int) table.getEntry("Mode").getNumber(0);
 
     headerPanel.remove(modeBox);
     switch (type) {
@@ -148,13 +151,13 @@ public class CANSpeedController extends AbstractTableWidget implements Controlle
   }
 
   @Override
-  public void booleanChanged(ITable source, String key, boolean value, boolean isNew) {
+  public void booleanChanged(NetworkTable source, String key, boolean value, boolean isNew) {
     pidControlPanel.booleanChanged(source, key, value, isNew);
     normalControlPanel.booleanChanged(source, key, value, isNew);
   }
 
   @Override
-  public void doubleChanged(ITable source, String key, double value, boolean isNew) {
+  public void doubleChanged(NetworkTable source, String key, double value, boolean isNew) {
     if ("Mode".equals(key)) {
       this.mode = (int) value;
       modeBox.setSelectedIndex(mode == TALON_DISABLED_MODE ? 6 : mode);
@@ -166,7 +169,7 @@ public class CANSpeedController extends AbstractTableWidget implements Controlle
   }
 
   @Override
-  public void stringChanged(ITable source, String key, String value, boolean isNew) {
+  public void stringChanged(NetworkTable source, String key, String value, boolean isNew) {
     if ("Type".equals(key)) {
       this.type = value;
     }
@@ -175,10 +178,11 @@ public class CANSpeedController extends AbstractTableWidget implements Controlle
   }
 
   @Override
-  public void valueChanged(ITable source, String key, Object value, boolean isNew) {
-    super.valueChanged(source, key, value, isNew);
-    pidControlPanel.valueChanged(source, key, value, isNew);
-    normalControlPanel.valueChanged(source, key, value, isNew);
+  public void valueChanged(NetworkTable source, String key, NetworkTableEntry entry, 
+                           NetworkTableValue value, int flags) {
+    super.valueChanged(source, key, entry, value, flags);
+    pidControlPanel.valueChanged(source, key, entry, value, flags);
+    normalControlPanel.valueChanged(source, key, entry, value, flags);
   }
 
   @Override

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/CANSpeedController.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/CANSpeedController.java
@@ -6,8 +6,7 @@ import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.CANSpeedControllerType;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
-import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.networktables.NetworkTableEvent;
 
 import java.awt.CardLayout;
 import java.awt.GridBagConstraints;
@@ -178,11 +177,10 @@ public class CANSpeedController extends AbstractTableWidget implements Controlle
   }
 
   @Override
-  public void valueChanged(NetworkTable source, String key, NetworkTableEntry entry, 
-                           NetworkTableValue value, int flags) {
-    super.valueChanged(source, key, entry, value, flags);
-    pidControlPanel.valueChanged(source, key, entry, value, flags);
-    normalControlPanel.valueChanged(source, key, entry, value, flags);
+  public void accept(NetworkTable source, String key, NetworkTableEvent event) {
+    super.accept(source, key, event);
+    pidControlPanel.accept(source, key, event);
+    normalControlPanel.accept(source, key, event);
   }
 
   @Override

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/DigitalInputDisplay.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/DigitalInputDisplay.java
@@ -4,7 +4,6 @@ import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.DigitalInputType;
-import edu.wpi.first.wpilibj.tables.ITableListener;
 import javax.swing.BoxLayout;
 
 /**
@@ -12,7 +11,7 @@ import javax.swing.BoxLayout;
  *
  * @author Sam
  */
-public class DigitalInputDisplay extends AbstractTableWidget implements ITableListener {
+public class DigitalInputDisplay extends AbstractTableWidget {
 
   public static final DataType[] TYPES = {DigitalInputType.get()};
 

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/DigitalOutputController.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/DigitalOutputController.java
@@ -41,7 +41,7 @@ public class DigitalOutputController extends AbstractTableWidget implements Cont
 
       public void actionPerformed(ActionEvent e) {
         controller.setText(controller.isSelected() ? "On" : "Off");
-        table.putBoolean("Value", controller.getText().equals("On"));
+        table.getEntry("Value").setBoolean(controller.getText().equals("On"));
       }
     });
     add(controller);

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/GyroDisplay.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/GyroDisplay.java
@@ -38,7 +38,7 @@ public class GyroDisplay extends AbstractTableWidget { // TODO: get the compass 
    * Options in a ComboBox for which display to show.
    */
   private final String[] names = {"Display as Text", "Display as Compass"};
-  private final JComboBox menu = new JComboBox(names);
+  private final JComboBox<String> menu = new JComboBox<String>(names);
 
   @Override
   public void init() {
@@ -56,7 +56,7 @@ public class GyroDisplay extends AbstractTableWidget { // TODO: get the compass 
 
     menu.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
-        JComboBox box = (JComboBox) e.getSource();
+        JComboBox<String> box = (JComboBox<String>) e.getSource();
         String name = box.getSelectedItem().toString();
         if (name.equals(names[1])) {
           self.remove(feedback);

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/LWSubsystem.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/LWSubsystem.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.SwingUtilities;
 import javax.swing.RowFilter.Entry;
@@ -69,11 +70,15 @@ public class LWSubsystem extends AbstractTableWidget {
    */
   public void init() {
     layout = new BoxLayout(this, BoxLayout.Y_AXIS);
+    var border = BorderFactory.createTitledBorder(getFieldName());
+    var borderWidth = 2*(border.getBorderInsets(this).left + border.getBorderInsets(this).right);
+    borderWidth += this.getFontMetrics(this.getFont()).stringWidth(getFieldName());
     setLayout(layout);
     setObstruction(true);
     setOpaque(true);
     setVisible(true);
-    setBorder(BorderFactory.createTitledBorder(getFieldName()));
+    add(Box.createHorizontalStrut(borderWidth));
+    setBorder(border);
     mouse = new Mouse(this);
     addMouseListener(mouse);
     addMouseMotionListener(mouse);

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/LWSubsystem.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/LWSubsystem.java
@@ -119,9 +119,9 @@ public class LWSubsystem extends AbstractTableWidget {
   }
 
   /**
-   * @param source Required by ITableListener. Not used.
-   * @param key The name of the changed table.
-   * @param isNew Required by ITableListener. Not used.
+   * @param parent The NetworkTable where the change occurred. Not used.
+   * @param key The name of the new table.
+   * @param newTable The newly created NetworkTable. Not used.
    */
   @Override
   public void tableCreated(final NetworkTable parent, final String key, 

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/PowerDistribution.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/PowerDistribution.java
@@ -4,7 +4,6 @@ import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.PowerDistributionType;
-import edu.wpi.first.wpilibj.tables.ITableListener;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -14,7 +13,7 @@ import javax.swing.JLabel;
 /**
  * Displays the current and voltage from the PDP
  */
-public class PowerDistribution extends AbstractTableWidget implements ITableListener {
+public class PowerDistribution extends AbstractTableWidget {
 
   public static final DataType[] TYPES = {PowerDistributionType.get()};
   

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/RelayController.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/RelayController.java
@@ -27,7 +27,7 @@ public class RelayController extends AbstractTableWidget implements Controller {
   public static final DataType[] TYPES = {RelayType.get(), DoubleSolenoidType.get()};
 
   private final String[] options = {"Forward", "Off", "Reverse"};
-  private final JComboBox controller = new JComboBox(options);
+  private final JComboBox<String> controller = new JComboBox<String>(options);
 
   @Override
   public void init() {
@@ -39,7 +39,7 @@ public class RelayController extends AbstractTableWidget implements Controller {
     controller.setSelectedIndex(1);
     controller.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
-        table.putString("Value", controller.getSelectedItem().toString());
+        table.getEntry("Value").setString(controller.getSelectedItem().toString());
       }
     });
     add(controller);
@@ -54,7 +54,7 @@ public class RelayController extends AbstractTableWidget implements Controller {
   }
 
   public void reset() {
-    table.putString("Value", "Off");
+    table.getEntry("Value").setString("Off");
     controller.setSelectedIndex(1);
   }
 

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/SingleNumberDisplay.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/SingleNumberDisplay.java
@@ -11,7 +11,6 @@ import edu.wpi.first.smartdashboard.types.named.GearToothSensorType;
 import edu.wpi.first.smartdashboard.types.named.TachometerType;
 import edu.wpi.first.smartdashboard.types.named.UltrasonicType;
 import edu.wpi.first.smartdashboard.types.named.UpDownCounterType;
-import edu.wpi.first.wpilibj.tables.ITableListener;
 import javax.swing.BoxLayout;
 
 
@@ -22,7 +21,7 @@ import javax.swing.BoxLayout;
  *
  * @author Sam
  */
-public class SingleNumberDisplay extends AbstractTableWidget implements ITableListener {
+public class SingleNumberDisplay extends AbstractTableWidget {
 
   public static final DataType[] TYPES = {AnalogInputType.get(),
       UltrasonicType.get(),

--- a/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/ThreeAxisAccelerometer.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/livewindow/elements/ThreeAxisAccelerometer.java
@@ -4,7 +4,6 @@ import edu.wpi.first.smartdashboard.gui.elements.bindings.AbstractTableWidget;
 import edu.wpi.first.smartdashboard.properties.Property;
 import edu.wpi.first.smartdashboard.types.DataType;
 import edu.wpi.first.smartdashboard.types.named.ThreeAxisAccelerometerType;
-import edu.wpi.first.wpilibj.tables.ITableListener;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -14,7 +13,7 @@ import javax.swing.JLabel;
 /**
  * Displays the X, Y and Z accelerations from a 3 axis accelerometer
  */
-public class ThreeAxisAccelerometer extends AbstractTableWidget implements ITableListener {
+public class ThreeAxisAccelerometer extends AbstractTableWidget {
 
   public static final DataType[] TYPES = {ThreeAxisAccelerometerType.get()};
 

--- a/src/main/java/edu/wpi/first/smartdashboard/robot/Robot.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/robot/Robot.java
@@ -1,8 +1,10 @@
 package edu.wpi.first.smartdashboard.robot;
 
-import edu.wpi.first.wpilibj.networktables.NetworkTable;
-import edu.wpi.first.wpilibj.tables.IRemoteConnectionListener;
-import edu.wpi.first.wpilibj.tables.ITable;
+import java.util.function.Consumer;
+
+import edu.wpi.first.networktables.ConnectionNotification;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 
 /**
  * @author Joe
@@ -16,17 +18,16 @@ public class Robot {
   public static final String identity = "SmartDashboard";
 
   private static volatile String _host = "";
-  private static volatile int _port = NetworkTable.DEFAULT_PORT;
+  private static volatile int _port = NetworkTableInstance.kDefaultPort;
+  private static final NetworkTableInstance ntInstance = NetworkTableInstance.getDefault();
 
   static {
-    NetworkTable.setClientMode();
-    NetworkTable.setNetworkIdentity(identity);
-    NetworkTable.initialize();
+    ntInstance.startClient(identity);
   }
 
   public static void setTeam(int team) {
     _host = "roboRIO-" + team + "-FRC.local";
-    NetworkTable.setTeam(team);
+    ntInstance.setServerTeam(team);
   }
 
   public static void setHost(String host) {
@@ -41,7 +42,7 @@ public class Robot {
     } else {
       _host = host;
       System.out.println("Host: " + host);
-      NetworkTable.setIPAddress(host);
+      ntInstance.setServer(host);
     }
   }
 
@@ -49,45 +50,32 @@ public class Robot {
     return _host;
   }
 
-  public static void setPort(int port) {
-    if (_port == port) {
-      return;
-    }
-    _port = port;
-    try {
-      NetworkTable.shutdown();
-    } catch (IllegalStateException ex) {
-      // TODO
-    }
-    NetworkTable.setPort(port);
-    NetworkTable.initialize();
+
+  public static NetworkTable getTable(String tableName) {
+    return ntInstance.getTable(tableName);
   }
 
-  public static ITable getTable(String tableName) {
-    return NetworkTable.getTable(tableName);
+  public static NetworkTable getTable() {
+    return ntInstance.getTable(TABLE_NAME);
   }
 
-  public static ITable getTable() {
-    return NetworkTable.getTable(TABLE_NAME);
+  public static NetworkTable getPreferences() {
+    return ntInstance.getTable(PREFERENCES_NAME);
   }
 
-  public static ITable getPreferences() {
-    return NetworkTable.getTable(PREFERENCES_NAME);
+  public static NetworkTable getLiveWindow() {
+    return ntInstance.getTable(LIVE_WINDOW_NAME);
   }
 
-  public static ITable getLiveWindow() {
-    return NetworkTable.getTable(LIVE_WINDOW_NAME);
-  }
-
-  public static void addConnectionListener(IRemoteConnectionListener listener, boolean
+  public static int addConnectionListener(Consumer<ConnectionNotification> listener, boolean
       immediateNotify) {
     System.out.println("Adding connection listener");
-    NetworkTable.getTable(TABLE_NAME).addConnectionListener(listener, immediateNotify);
+    return ntInstance.addConnectionListener(listener, immediateNotify);
   }
 
-  public static void removeConnectionListener(IRemoteConnectionListener listener) {
+  public static void removeConnectionListener(int listenerHandle) {
     System.out.println("Removing connection listener");
-    NetworkTable.getTable(TABLE_NAME).removeConnectionListener(listener);
+    ntInstance.removeConnectionListener(listenerHandle);
   }
 
 }

--- a/src/main/java/edu/wpi/first/smartdashboard/robot/Robot.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/robot/Robot.java
@@ -2,8 +2,8 @@ package edu.wpi.first.smartdashboard.robot;
 
 import java.util.function.Consumer;
 
-import edu.wpi.first.networktables.ConnectionNotification;
 import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
 /**
@@ -18,11 +18,11 @@ public class Robot {
   public static final String identity = "SmartDashboard";
 
   private static volatile String _host = "";
-  private static volatile int _port = NetworkTableInstance.kDefaultPort;
+  private static volatile int _port = NetworkTableInstance.kDefaultPort3;
   private static final NetworkTableInstance ntInstance = NetworkTableInstance.getDefault();
 
   static {
-    ntInstance.startClient(identity);
+    ntInstance.startClient3(identity);
   }
 
   public static void setTeam(int team) {
@@ -67,15 +67,16 @@ public class Robot {
     return ntInstance.getTable(LIVE_WINDOW_NAME);
   }
 
-  public static int addConnectionListener(Consumer<ConnectionNotification> listener, boolean
+  public static int addConnectionListener(Consumer<NetworkTableEvent> listener, boolean
       immediateNotify) {
     System.out.println("Adding connection listener");
-    return ntInstance.addConnectionListener(listener, immediateNotify);
+    return ntInstance.addConnectionListener(true, listener);
+
   }
 
   public static void removeConnectionListener(int listenerHandle) {
     System.out.println("Removing connection listener");
-    ntInstance.removeConnectionListener(listenerHandle);
+    ntInstance.removeListener(listenerHandle);
   }
 
 }

--- a/src/main/java/edu/wpi/first/smartdashboard/types/DataType.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/types/DataType.java
@@ -1,8 +1,8 @@
 package edu.wpi.first.smartdashboard.types;
 
+import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.smartdashboard.gui.Widget;
 import edu.wpi.first.smartdashboard.gui.elements.TextBox;
-import edu.wpi.first.wpilibj.tables.ITable;
 
 /**
  * @author Joe Grinstead
@@ -86,11 +86,11 @@ public class DataType {
   public static DataType getType(Object value) {
     if (value == null) {
       throw new IllegalArgumentException("Can not be given null value");
-    } else if (value instanceof ITable) {
-      ITable table = (ITable) value;
+    } else if (value instanceof NetworkTable) {
+      NetworkTable table = (NetworkTable) value;
 
       if (table.containsKey(".type")) {
-        String typeName = table.getString(".type", null);
+        String typeName = table.getEntry(".type").getString(null);
         return NamedDataType.get(typeName);
       } else {
         return DataType.TABLE;

--- a/src/main/java/edu/wpi/first/smartdashboard/types/NamedDataType.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/types/NamedDataType.java
@@ -12,7 +12,8 @@ public class NamedDataType extends DataType {
   private static final Map<String, NamedDataType> map = new HashMap<String, NamedDataType>();
 
   public static NamedDataType get(String name) {
-    return map.get(name);
+    var type = map.get(name);
+    return type;
   }
 
   protected NamedDataType(String name, DataType... parents) {

--- a/src/main/java/edu/wpi/first/smartdashboard/types/named/SchedulerType.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/types/named/SchedulerType.java
@@ -1,7 +1,6 @@
 package edu.wpi.first.smartdashboard.types.named;
 
 import edu.wpi.first.smartdashboard.types.NamedDataType;
-import edu.wpi.first.smartdashboard.gui.elements.Scheduler;
 
 /**
  * @author Joe Grinstead

--- a/src/main/java/edu/wpi/first/smartdashboard/types/named/SchedulerType.java
+++ b/src/main/java/edu/wpi/first/smartdashboard/types/named/SchedulerType.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.smartdashboard.types.named;
 
 import edu.wpi.first.smartdashboard.types.NamedDataType;
+import edu.wpi.first.smartdashboard.gui.elements.Scheduler;
 
 /**
  * @author Joe Grinstead
@@ -10,6 +11,8 @@ public class SchedulerType extends NamedDataType {
   public static final String LABEL = "Scheduler";
 
   private SchedulerType() {
+    // super(LABEL, Scheduler.class); -- the Scheduler widget doesn't
+    //  really work, so let's not use it.
     super(LABEL);
   }
 


### PR DESCRIPTION
I'm posting this as a preliminary effort, not yet ready for merging.

After having some issues with SmartDashboard this season I thought I would attempt to contribute an update to use current NetworkTables APIs rather than being forever stuck on the ITable inteface that was already deprecated in 2021.

This is the state of things so far. There are a number of issues:
* There doesn't actually seem to be a usable WPILib-2023.4.3 wpilibTools dep. Setting `wpilibTools.deps.wpilibVersion = "2023.4.3` in `dependencies.gradle` results in compilation errors due to missing files. I was able to compile with `wpilibTools.deps.wpilibVersion = "2023.4.3-1-g663703d"`.
* Having succeeded at compiling, I then found that the code would not run, either from the Run|Debug menu or directly using `./gradlew :run`, due to being unable to find `libwpinet.so` in the place(s) it was looking. I couldn't figure out how to get gradle to look anyplace else, so I just copied a recent `libwpinet.so` that I found elsewhere on my computer to where it was looking. (As you've noticed by now , I'm developing on Linux.)
* SmartDashboard has a widget for creating a set of persistent preferences. Adding preferences using the Widget works: they get created and are visible in the `Persistent` section of glass and the simulation dashboard. Restarting the robot code (simulation) repopulates the values as expected. The Remove functionality does not work. I suspect that once the values are created the NT Server running on the robot begins publishing them. I think what is happening is that with the current NT interfaces, as I understand things, there is no "Delete" operation -- rather one just unpublishes. But this doesn't work in this scenario. SmartDashboard originally published the values but now there is another publisher. Unpublishing from SmartDashboard doesn't do anything. Insight about what to do to fix this would be much appreciated.
* Similarly, SmartDashboard has a widget for the Sendable instance of the Robot Scheduler. It has buttons that allow Cancelling running commands. In the released version this functionality is completely broken -- pushing a Cancel button results in a Java exception prior to doing anything with NetworkTables. With that fixed, this version actually is able to cancel commands (visible in the Scheduler state as reported by the Simulation dashboard and OutlineViewer). However, The Scheduler's acknowledgement of the cancellation, by writing an empty int[] value to the Cancel key of the Scheduler Sendable, does not work. In my understanding, again, numeric values are only sent to subscribers as doubles. So the Robot code sees the Cancel list as double[] but then attempts to write to it as int[] and fails. Thus once a value has been put in the Cancel list by SmartDashboard it never gets cleared and the Scheduler cancels that command whenever it gets run. Once again, insight about how to proceed would be appreciated.

This is my first foray into programming directly with the NT API so please excuse and correct any awkwardnesses that I may have committed. One question that I have about the API is that it has interfaces named both `TableListener` and `SubTableListener` that appear essentially identical. I think I eventually decided I needed `SubTableListener`, but I'm wondering about the use of `TableListener`.
