### PR TITLE
Enable release mode for untagged builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,8 @@ jobs:
           (startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/v'))
 
       - name: Build with Gradle
-        run: ./gradlew build -PbuildServer -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }}
+        # enable release mode due to missing development mode artifacts. If NT is ever updated, release mode can be removed
+        run: ./gradlew build -PbuildServer -PreleaseMode -PdeveloperID=${{ secrets.APPLE_DEVELOPER_ID }}
         if: ${{ !github.repository_owner == 'wpilibsuite' || !startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build with Gradle (Release)


### PR DESCRIPTION
Works around missing development artifacts for NT from 2021